### PR TITLE
[build] Renaming to InetStack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
   run-demikernel0:
     name: Demikernel 0
     needs: [build-demikernel0]
-    uses: demikernel/catnip/.github/workflows/run.yml@dev
+    uses: demikernel/inetstack/.github/workflows/run.yml@dev
     secrets:
       host: ${{ secrets.CATNAP_HOSTNAME_A }}
       port: ${{ secrets.PORTNUM }}
@@ -94,7 +94,7 @@ jobs:
   run-demikernel1:
     name: Demikernel 1
     needs: [build-demikernel1]
-    uses: demikernel/catnip/.github/workflows/run.yml@dev
+    uses: demikernel/inetstack/.github/workflows/run.yml@dev
     secrets:
       host: ${{ secrets.CATNAP_HOSTNAME_B }}
       port: ${{ secrets.PORTNUM }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "catnip"
+name = "inetstack"
 version = "0.8.0"
 authors = [ "Microsoft Corporation" ]
 description = "Fast User-Space TCP/UDP Stack"
 homepage = "https://aka.ms/demikernel"
-repository = "https://github.com/demikernel/catnip"
+repository = "https://github.com/demikernel/inetstack"
 readme = "README.md"
 license-file = "LICENSE.txt"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-Catnip
-=======
+Demikernel's TCP/UDP Stack
+===========================
 
-[![Build](https://github.com/demikernel/catnip/actions/workflows/build.yml/badge.svg)](https://github.com/demikernel/catnip/actions/workflows/build.yml)
-[![Test](https://github.com/demikernel/catnip/actions/workflows/test.yml/badge.svg)](https://github.com/demikernel/catnip/actions/workflows/test.yml)
+[![Build](https://github.com/demikernel/inetstack/actions/workflows/build.yml/badge.svg)](https://github.com/demikernel/inetstack/actions/workflows/build.yml)
+[![Test](https://github.com/demikernel/inetstack/actions/workflows/test.yml/badge.svg)](https://github.com/demikernel/inetstack/actions/workflows/test.yml)
 
 _Catnip_ is a TCP/IP stack that focuses on being an embeddable, low-latency
 solution for user-space networking.
@@ -19,7 +19,8 @@ Building and Running
 ```
 export WORKDIR=$HOME                                  # Change this to whatever you want.
 cd $WORKDIR                                           # Switch to working directory.
-git clone https://github.com/demikernel/catnip.git    # Clone.
+git clone https://github.com/demikernel/inetstack.git # Clone.
+cd $WORKDIR/inetstack                                 # Switch to repository's source tree.
 ```
 
 **2. Install Prerequisites**
@@ -27,16 +28,14 @@ git clone https://github.com/demikernel/catnip.git    # Clone.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh    # Get Rust toolchain.
 ```
 
-**3. Build Catnip**
+**3. Build**
 ```
-cd $WORKDIR/catnip    # Switch to working directory.
-cargo build           # Build catnip.
+make
 ```
 
-**4. Run Regression Tests**
+**4. Run Regression Tests (Optional)**
 ```
-cd $WORKDIR/catnip               # Switch to working directory.
-cargo test -- --test-threads 1   # Run with a single-thread.
+make test
 ```
 
 Code of Conduct

--- a/src/protocols/tcp/segment.rs
+++ b/src/protocols/tcp/segment.rs
@@ -432,7 +432,7 @@ impl TcpHeader {
         }
     }
 
-    // TODO: Review the use of usize here (and everywhere in catnip, really).
+    // TODO: Review the use of usize here (and everywhere in inetstack, really).
     pub fn compute_size(&self) -> usize {
         let mut size = MIN_TCP_HEADER_SIZE;
         for i in 0..self.num_options {

--- a/tests/common/libos.rs
+++ b/tests/common/libos.rs
@@ -6,7 +6,7 @@
 //==============================================================================
 
 use super::runtime::DummyRuntime;
-use ::catnip::Catnip;
+use ::inetstack::InetStack;
 use ::crossbeam_channel::{Receiver, Sender};
 use ::runtime::{
     logging,
@@ -33,11 +33,11 @@ impl DummyLibOS {
         tx: Sender<Bytes>,
         rx: Receiver<Bytes>,
         arp: HashMap<Ipv4Addr, MacAddress>,
-    ) -> Catnip<DummyRuntime> {
+    ) -> InetStack<DummyRuntime> {
         let now: Instant = Instant::now();
         let rt: DummyRuntime = DummyRuntime::new(now, link_addr, ipv4_addr, rx, tx, arp);
         logging::initialize();
-        Catnip::new(rt).unwrap()
+        InetStack::new(rt).unwrap()
     }
 
     /// Cooks a buffer.

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -12,7 +12,7 @@ mod common;
 use crate::common::{
     arp, libos::*, runtime::DummyRuntime, ALICE_IPV4, ALICE_MAC, BOB_IPV4, BOB_MAC, PORT_BASE,
 };
-use ::catnip::{operations::OperationResult, protocols::ipv4::Ipv4Endpoint, Catnip};
+use ::inetstack::{operations::OperationResult, protocols::ipv4::Ipv4Endpoint, InetStack};
 use ::crossbeam_channel::{self, Receiver, Sender};
 use ::runtime::{fail::Fail, memory::Bytes, network::types::Port16, QDesc, QToken};
 use ::std::{
@@ -26,7 +26,7 @@ use ::std::{
 //==============================================================================
 
 /// Tests if a passive socket may be successfully opened and closed.
-fn do_tcp_connection_setup(libos: &mut Catnip<DummyRuntime>, port: u16) {
+fn do_tcp_connection_setup(libos: &mut InetStack<DummyRuntime>, port: u16) {
     let port: Port16 = Port16::try_from(port).unwrap();
     let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, port);
 
@@ -43,7 +43,7 @@ fn do_tcp_connection_setup(libos: &mut Catnip<DummyRuntime>, port: u16) {
 #[test]
 fn catnip_tcp_connection_setup() {
     let (tx, rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
-    let mut libos: Catnip<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
+    let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     do_tcp_connection_setup(&mut libos, PORT_BASE);
 }
@@ -58,7 +58,7 @@ fn do_tcp_establish_connection(port: u16) {
     let (bob_tx, bob_rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
 
         let port: Port16 = Port16::try_from(port).unwrap();
@@ -91,7 +91,7 @@ fn do_tcp_establish_connection(port: u16) {
     });
 
     let bob: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(BOB_MAC, BOB_IPV4, bob_tx, alice_rx, arp());
 
         let port: Port16 = Port16::try_from(port).unwrap();
@@ -135,7 +135,7 @@ fn do_tcp_push_remote(port: u16) {
     let (bob_tx, bob_rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
 
         let port: Port16 = Port16::try_from(port).unwrap();
@@ -178,7 +178,7 @@ fn do_tcp_push_remote(port: u16) {
     });
 
     let bob: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(BOB_MAC, BOB_IPV4, bob_tx, alice_rx, arp());
 
         let port: Port16 = Port16::try_from(port).unwrap();
@@ -233,7 +233,7 @@ fn catnip_tcp_push_remote() {
 /// Tests for bad socket creation.
 fn do_tcp_bad_socket() {
     let (tx, rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
-    let mut libos: Catnip<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
+    let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     let domains: Vec<libc::c_int> = vec![
         libc::AF_ALG,
@@ -319,7 +319,7 @@ fn catnip_tcp_bad_socket() {
 /// Test bad calls for `bind()`.
 fn do_tcp_bad_bind(port: u16) {
     let (tx, rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
-    let mut libos: Catnip<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
+    let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     // Invalid file descriptor.
     let port: Port16 = Port16::try_from(port).unwrap();
@@ -340,7 +340,7 @@ fn catnip_tcp_bad_bind() {
 /// Tests bad calls for `listen()`.
 fn do_tcp_bad_listen(port: u16) {
     let (tx, rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
-    let mut libos: Catnip<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
+    let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     let port: Port16 = Port16::try_from(port).unwrap();
     let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, port);
@@ -369,7 +369,7 @@ fn catnip_tcp_bad_listen() {
 /// Tests bad calls for `accept()`.
 fn do_tcp_bad_accept() {
     let (tx, rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
-    let mut libos: Catnip<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
+    let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     // Invalid file descriptor.
     let e: Fail = libos.accept(QDesc::from(0)).unwrap_err();
@@ -391,7 +391,7 @@ fn do_tcp_bad_connect(port: u16) {
     let (bob_tx, bob_rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
 
     let alice: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
         let port: Port16 = Port16::try_from(port).unwrap();
         let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, port);
@@ -424,7 +424,7 @@ fn do_tcp_bad_connect(port: u16) {
     });
 
     let bob: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(BOB_MAC, BOB_IPV4, bob_tx, alice_rx, arp());
 
         let port: Port16 = Port16::try_from(port).unwrap();

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -12,7 +12,7 @@ mod common;
 use crate::common::{
     arp, libos::*, runtime::DummyRuntime, ALICE_IPV4, ALICE_MAC, BOB_IPV4, BOB_MAC, PORT_BASE,
 };
-use ::catnip::{operations::OperationResult, protocols::ipv4::Ipv4Endpoint, Catnip};
+use ::inetstack::{operations::OperationResult, protocols::ipv4::Ipv4Endpoint, InetStack};
 use ::crossbeam_channel::{self, Receiver, Sender};
 use ::runtime::{memory::Bytes, network::types::Port16, QDesc, QToken};
 use ::std::{
@@ -29,7 +29,7 @@ use ::std::{
 #[test]
 fn udp_connect_remote() {
     let (tx, rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
-    let mut libos: Catnip<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
+    let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     let port: Port16 = Port16::try_from(PORT_BASE).unwrap();
     let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, port);
@@ -44,7 +44,7 @@ fn udp_connect_remote() {
 #[test]
 fn udp_connect_loopback() {
     let (tx, rx): (Sender<Bytes>, Receiver<Bytes>) = crossbeam_channel::unbounded();
-    let mut libos: Catnip<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
+    let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     let port: Port16 = Port16::try_from(PORT_BASE).unwrap();
     let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, port);
@@ -72,7 +72,7 @@ fn udp_push_remote() {
     let alice_addr: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, alice_port);
 
     let alice: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
 
         // Open connection.
@@ -109,7 +109,7 @@ fn udp_push_remote() {
     });
 
     let bob: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(BOB_MAC, BOB_IPV4, bob_tx, alice_rx, arp());
 
         // Open connection.
@@ -158,7 +158,7 @@ fn udp_loopback() {
     let alice_addr: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, alice_port);
 
     let alice: JoinHandle<()> = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(ALICE_MAC, ALICE_IPV4, alice_tx, bob_rx, arp());
 
         // Open connection.
@@ -195,7 +195,7 @@ fn udp_loopback() {
     });
 
     let bob = thread::spawn(move || {
-        let mut libos: Catnip<DummyRuntime> =
+        let mut libos: InetStack<DummyRuntime> =
             DummyLibOS::new(ALICE_MAC, ALICE_IPV4, bob_tx, alice_rx, arp());
 
         // Open connection.


### PR DESCRIPTION
Description
========

In this PR I rename the repository and all concerned code/documentation to InetStack, a shorthand for "Internet Stack".

The main reason for this change is to avoid misleading interpretation to external contributors.