### PR TITLE
[tcp] Remove Queue Descriptor When Closing a Connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,9 @@ impl<RT: Runtime> InetStack<RT> {
             _ => Err(Fail::new(EBADF, "bad queue descriptor")),
         }?;
 
-        Ok(self.rt.schedule(future).into_raw().into())
+        let qt: QToken = self.rt.schedule(future).into_raw().into();
+        trace!("connect() qt={:?}", qt);
+        Ok(qt)
     }
 
     ///
@@ -339,7 +341,7 @@ impl<RT: Runtime> InetStack<RT> {
         // Issue operation.
         let future: FutureOperation<RT> = self.do_push(qd, buf)?;
         let qt: QToken = self.rt.schedule(future).into_raw().into();
-
+        trace!("push2() qt={:?}", qt);
         Ok(qt)
     }
 
@@ -374,7 +376,7 @@ impl<RT: Runtime> InetStack<RT> {
         // Issue operation.
         let future: FutureOperation<RT> = self.do_pushto(qd, buf, remote)?;
         let qt: QToken = self.rt.schedule(future).into_raw().into();
-
+        trace!("pushto2() qt={:?}", qt);
         Ok(qt)
     }
 
@@ -398,7 +400,9 @@ impl<RT: Runtime> InetStack<RT> {
             _ => Err(Fail::new(EBADF, "bad queue descriptor")),
         }?;
 
-        Ok(self.rt.schedule(future).into_raw().into())
+        let qt: QToken = self.rt.schedule(future).into_raw().into();
+        trace!("pop() qt={:?}", qt);
+        Ok(qt)
     }
 
     /// Waits for an operation to complete.
@@ -419,6 +423,7 @@ impl<RT: Runtime> InetStack<RT> {
 
             // The operation has completed, so extract the result and return.
             if handle.has_completed() {
+                trace!("wait2() qt={:?} completed!", qt);
                 return Ok(self.take_operation(handle));
             }
         }

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -298,12 +298,12 @@ impl<RT: Runtime> TcpPeer<RT> {
     }
 
     /// Closes a TCP socket.
-    pub fn do_close(&self, fd: QDesc) -> Result<(), Fail> {
-        let inner = self.inner.borrow_mut();
+    pub fn do_close(&self, qd: QDesc) -> Result<(), Fail> {
+        let mut inner: RefMut<Inner<RT>> = self.inner.borrow_mut();
 
-        match inner.sockets.get(&fd) {
+        match inner.sockets.remove(&qd) {
             Some(Socket::Established { local, remote }) => {
-                let key = (*local, *remote);
+                let key: (Ipv4Endpoint, Ipv4Endpoint) = (local, remote);
                 match inner.established.get(&key) {
                     Some(ref s) => s.close()?,
                     None => return Err(Fail::new(ENOTCONN, "connection not established")),


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/inetstack/issues/160.

Here is a summary of changes:
- I introduced some traces to help debugging interactions with the scheduler
- I replaced `get()` lookup in the sockets table by `remove()` to fix the bug