### PR TITLE
[tcp] Fixes Bugs in `bind()`

### DIFF
--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -309,6 +309,18 @@ fn tcp_bad_bind() {
         Ok(_) => panic!("bind() socket multiple times should fail with EINVAL"),
     };
     safe_close_passive(&mut libos, sockqd);
+
+    // Bind sockets to same address.
+    let sockqd_a: QDesc = safe_socket(&mut libos);
+    let sockqd_b: QDesc = safe_socket(&mut libos);
+    safe_bind(&mut libos, sockqd_a, local);
+    match libos.bind(sockqd_b, local) {
+        Err(e) if e.errno == libc::EADDRINUSE => (),
+        Err(e) => panic!("bind() failed with unexpected error code ({:?})", e),
+        Ok(_) => panic!("bind() multiple sockets to the same address should fail with EADDRINUSE"),
+    };
+    safe_close_passive(&mut libos, sockqd_a);
+    safe_close_passive(&mut libos, sockqd_b);
 }
 
 //======================================================================================================================

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -291,13 +291,24 @@ fn tcp_bad_bind() {
     let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
+    let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, safe_try_port16(PORT_BASE));
+    let local2: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, safe_try_port16(PORT_BASE + 1));
+
     // Invalid queue descriptor.
-    let port: Port16 = safe_try_port16(PORT_BASE);
-    let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, port);
     match libos.bind(QDesc::from(0), local) {
         Err(e) if e.errno == libc::EBADF => (),
         _ => panic!("invalid call to bind() should failed with EBADF"),
     };
+
+    // Bind socket multiple times.
+    let sockqd: QDesc = safe_socket(&mut libos);
+    safe_bind(&mut libos, sockqd, local);
+    match libos.bind(sockqd, local2) {
+        Err(e) if e.errno == libc::EINVAL => (),
+        Err(e) => panic!("bind() failed with unexpected error code ({:?})", e),
+        Ok(_) => panic!("bind() socket multiple times should fail with EINVAL"),
+    };
+    safe_close_passive(&mut libos, sockqd);
 }
 
 //======================================================================================================================


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/inetstack/issues/100.
This PR Fixes https://github.com/demikernel/inetstack/issues/165.

Digest
--------

- Introduced unit tests to cover both isues
- Fixed issue https://github.com/demikernel/inetstack/issues/100 by adding match statement to check if socket is already bound.
- Fixed issue https://github.com/demikernel/inetstack/issues/165 by adding a check that traverses the sockets table and find out if there is any socket using that given local address.


Further Considerations
--------------------------

- A better fix for https://github.com/demikernel/inetstack/issues/165 would be to add a hashmap that keeps track of local addresses that are bound. However,this would introduce an additional table in our code. I believe that we could deal this in an enhancement, by simply restructuring the tables that we already have to provide this binding information.