### PR TITLE
[ipv4] Don't Fail When Parsing Optional Features

### DIFF
--- a/src/protocols/ipv4/datagram.rs
+++ b/src/protocols/ipv4/datagram.rs
@@ -146,10 +146,8 @@ impl Ipv4Header {
 
         // Differentiated services code point.
         let dscp: u8 = hdr_buf[1] >> 2;
-        // TODO: drop this check once we support DSCP.
         if dscp != 0 {
-            warn!("differentiated services code point are not supported dscp={:?}", dscp);
-            return Err(Fail::new(ENOTSUP, "ipv4 dscp is not supported"));
+            warn!("ignoring dscp field (dscp={:?})", dscp);
         }
 
         // Explicit congestion notification.

--- a/src/protocols/ipv4/datagram.rs
+++ b/src/protocols/ipv4/datagram.rs
@@ -152,10 +152,8 @@ impl Ipv4Header {
 
         // Explicit congestion notification.
         let ecn: u8 = hdr_buf[1] & 3;
-        // TODO: drop this check once we support ECN.
         if ecn != 0 {
-            warn!("explicit congestion notification is not supported ecn={:?}", ecn);
-            return Err(Fail::new(ENOTSUP, "ipv4 ecn is not supported"));
+            warn!("ignoring ecn field (ecn={:?})", ecn);
         }
 
         // Total length.

--- a/src/protocols/ipv4/tests.rs
+++ b/src/protocols/ipv4/tests.rs
@@ -471,8 +471,6 @@ fn test_ipv4_header_parse_unsupported_dscp() {
 }
 
 /// Parses a malformed IPv4 header with unsupported ECN field.
-///
-/// TODO: Drop this test once we support ECN.
 #[test]
 fn test_ipv4_header_parse_unsupported_ecn() {
     const HEADER_SIZE: usize = 20;
@@ -502,8 +500,8 @@ fn test_ipv4_header_parse_unsupported_ecn() {
         // Do it.
         let buf_bytes: Box<dyn Buffer> = Box::new(DataBuffer::from_slice(&buf));
         match Ipv4Header::parse(buf_bytes) {
-            Ok(_) => assert!(false, "parsed ipv4 header with ecn={:?}. Do we support it now?", ecn),
-            Err(_) => {},
+            Ok(_) => {},
+            Err(_) => panic!("ecn field should be ignored (ecn={:?})", ecn),
         };
     }
 }

--- a/src/protocols/ipv4/tests.rs
+++ b/src/protocols/ipv4/tests.rs
@@ -435,8 +435,6 @@ fn test_ipv4_header_parse_unsupported_ihl() {
 }
 
 /// Parses a malformed IPv4 header with unsupported DSCP field.
-///
-/// TODO: Drop this test once we support DSCP.
 #[test]
 fn test_ipv4_header_parse_unsupported_dscp() {
     const HEADER_SIZE: usize = 20;
@@ -466,8 +464,8 @@ fn test_ipv4_header_parse_unsupported_dscp() {
         // Do it.
         let buf_bytes: Box<dyn Buffer> = Box::new(DataBuffer::from_slice(&buf));
         match Ipv4Header::parse(buf_bytes) {
-            Ok(_) => assert!(false, "parsed ipv4 header with dscp={:?}. Do we support it now?", dscp),
-            Err(_) => {},
+            Ok(_) => {},
+            Err(_) => panic!("dscp field should be ignored (dscp={:?})", dscp),
         };
     }
 }


### PR DESCRIPTION
Description
--------------

This PR fixes https://github.com/demikernel/inetstack/issues/117.

Summary of Changes
------------------------
- Dropped failure return when parsing packet with `DSCP` flags.
- Dropped failure return when parsing packet with `ECN` flags.
- Fixed unit tests in IPv4 accordingly.