### PR TITLE
[tcp] Several Bug Fixes for `listen()`

### DIFF
--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -191,6 +191,12 @@ impl<RT: Runtime> TcpPeer<RT> {
             Some(Socket::Inactive { local: None }) => {
                 return Err(Fail::new(libc::EDESTADDRREQ, "socket is not bound to a local address"))
             },
+            Some(Socket::Connecting { local: _, remote: _ }) => {
+                return Err(Fail::new(libc::EINVAL, "socket is connecting"))
+            },
+            Some(Socket::Established { local: _, remote: _ }) => {
+                return Err(Fail::new(libc::EINVAL, "socket is connected"))
+            },
             _ => return Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
         };
 

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -42,7 +42,6 @@ use crate::protocols::{
 };
 use ::futures::channel::mpsc;
 use ::libc::{
-    EADDRNOTAVAIL,
     EAGAIN,
     EBADF,
     EBADMSG,
@@ -179,20 +178,32 @@ impl<RT: Runtime> TcpPeer<RT> {
         self.inner.borrow_mut().receive(ip_header, buf)
     }
 
-    pub fn listen(&self, fd: QDesc, backlog: usize) -> Result<(), Fail> {
-        let mut inner = self.inner.borrow_mut();
-        let local = match inner.sockets.get_mut(&fd) {
+    // Marks the target socket as passive.
+    pub fn listen(&self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
+        let mut inner: RefMut<Inner<RT>> = self.inner.borrow_mut();
+
+        // Get bound address while checking for several issues.
+        let local: Ipv4Endpoint = match inner.sockets.get_mut(&qd) {
             Some(Socket::Inactive { local: Some(local) }) => *local,
-            _ => return Err(Fail::new(EBADF, "invalid queue descriptor")),
+            Some(Socket::Listening { local: _ }) => {
+                return Err(Fail::new(libc::EADDRINUSE, "socket is already listening"))
+            },
+            _ => return Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
         };
-        // TODO: Should this move to bind?
-        if inner.passive.contains_key(&local) {
-            return Err(Fail::new(EADDRNOTAVAIL, "port already in use"));
+
+        // Check if there isn't a socket listening on this address/port pair.
+        for (addr, _) in &inner.passive {
+            if *addr == local {
+                return Err(Fail::new(
+                    libc::EADDRINUSE,
+                    "another socket is already listening on the same address/port pair",
+                ));
+            }
         }
 
-        let socket = PassiveSocket::new(local, backlog, inner.rt.clone(), inner.arp.clone());
+        let socket: PassiveSocket<RT> = PassiveSocket::new(local, backlog, inner.rt.clone(), inner.arp.clone());
         assert!(inner.passive.insert(local, socket).is_none());
-        inner.sockets.insert(fd, Socket::Listening { local });
+        inner.sockets.insert(qd, Socket::Listening { local });
         Ok(())
     }
 

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -188,6 +188,9 @@ impl<RT: Runtime> TcpPeer<RT> {
             Some(Socket::Listening { local: _ }) => {
                 return Err(Fail::new(libc::EADDRINUSE, "socket is already listening"))
             },
+            Some(Socket::Inactive { local: None }) => {
+                return Err(Fail::new(libc::EDESTADDRREQ, "socket is not bound to a local address"))
+            },
             _ => return Err(Fail::new(libc::EBADF, "invalid queue descriptor")),
         };
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -349,6 +349,16 @@ fn tcp_bad_listen() {
         _ => panic!("invalid call to listen() should fail with EINVAL"),
     };
     safe_close_passive(&mut libos, sockqd);
+
+    // Listen multiple times same address/part pair.
+    let sockqd: QDesc = safe_socket(&mut libos);
+    safe_bind(&mut libos, sockqd, local);
+    safe_listen(&mut libos, sockqd);
+    match libos.listen(sockqd, 16) {
+        Err(e) if e.errno == libc::EADDRINUSE => (),
+        _ => panic!("listen() multiple times should fail with EADDRINUSE"),
+    };
+    safe_close_passive(&mut libos, sockqd);
 }
 
 //======================================================================================================================

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -297,7 +297,7 @@ fn tcp_bad_bind() {
     // Invalid queue descriptor.
     match libos.bind(QDesc::from(0), local) {
         Err(e) if e.errno == libc::EBADF => (),
-        _ => panic!("invalid call to bind() should failed with EBADF"),
+        _ => panic!("invalid call to bind() should fail with EBADF"),
     };
 
     // Bind socket multiple times.
@@ -339,7 +339,7 @@ fn tcp_bad_listen() {
     // Invalid queue descriptor.
     match libos.listen(QDesc::from(0), 8) {
         Err(e) if e.errno == libc::EBADF => (),
-        _ => panic!("invalid call to listen() should failed with EBADF"),
+        _ => panic!("invalid call to listen() should fail with EBADF"),
     };
 
     // Invalid backlog length
@@ -347,7 +347,7 @@ fn tcp_bad_listen() {
     safe_bind(&mut libos, sockqd, local);
     match libos.listen(sockqd, 0) {
         Err(e) if e.errno == libc::EINVAL => (),
-        _ => panic!("invalid call to listen() should failed with EINVAL"),
+        _ => panic!("invalid call to listen() should fail with EINVAL"),
     };
 
     // Close socket.
@@ -367,7 +367,7 @@ fn tcp_bad_accept() {
     // Invalid queue descriptor.
     match libos.accept(QDesc::from(0)) {
         Err(e) if e.errno == libc::EBADF => (),
-        _ => panic!("invalid call to accept() should failed with EBADF"),
+        _ => panic!("invalid call to accept() should fail with EBADF"),
     };
 }
 
@@ -411,7 +411,7 @@ fn tcp_bad_connect() {
         // Bad queue descriptor.
         match libos.connect(QDesc::from(0), remote) {
             Err(e) if e.errno == libc::EBADF => (),
-            _ => panic!("invalid call to connect() should failed with EBADF"),
+            _ => panic!("invalid call to connect() should fail with EBADF"),
         };
 
         // Bad endpoint.

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -333,8 +333,7 @@ fn tcp_bad_listen() {
     let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
-    let port: Port16 = safe_try_port16(PORT_BASE);
-    let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, port);
+    let local: Ipv4Endpoint = Ipv4Endpoint::new(ALICE_IPV4, safe_try_port16(PORT_BASE));
 
     // Invalid queue descriptor.
     match libos.listen(QDesc::from(0), 8) {
@@ -349,8 +348,6 @@ fn tcp_bad_listen() {
         Err(e) if e.errno == libc::EINVAL => (),
         _ => panic!("invalid call to listen() should fail with EINVAL"),
     };
-
-    // Close socket.
     safe_close_passive(&mut libos, sockqd);
 }
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -350,15 +350,17 @@ fn tcp_bad_listen() {
     };
     safe_close_passive(&mut libos, sockqd);
 
-    // Listen multiple times same address/part pair.
+    // Listen on an already listening socket.
     let sockqd: QDesc = safe_socket(&mut libos);
     safe_bind(&mut libos, sockqd, local);
     safe_listen(&mut libos, sockqd);
     match libos.listen(sockqd, 16) {
-        Err(e) if e.errno == libc::EADDRINUSE => (),
-        _ => panic!("listen() multiple times should fail with EADDRINUSE"),
+        Err(e) if e.errno == libc::EINVAL => (),
+        _ => panic!("listen() called on an already listening socket should fail with EINVAL"),
     };
     safe_close_passive(&mut libos, sockqd);
+
+    // TODO: Add unit test for "Listen on an in-use address/port pair." (see issue #178).
 
     // Listen on unbound socket.
     let sockqd: QDesc = safe_socket(&mut libos);

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -359,6 +359,15 @@ fn tcp_bad_listen() {
         _ => panic!("listen() multiple times should fail with EADDRINUSE"),
     };
     safe_close_passive(&mut libos, sockqd);
+
+    // Listen on unbound socket.
+    let sockqd: QDesc = safe_socket(&mut libos);
+    match libos.listen(sockqd, 16) {
+        Err(e) if e.errno == libc::EDESTADDRREQ => (),
+        Err(e) => panic!("listen() to unbound address should fail with EDESTADDRREQ {:?}", e),
+        _ => panic!("should fail"),
+    };
+    safe_close_passive(&mut libos, sockqd);
 }
 
 //======================================================================================================================


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/inetstack/issues/170.

Summary of Changes
------------------------
- Fixed `listen()` to return `EADDRINUSE` when there is a socket listening on the target address/port pair.
- Fixed `listen()` to return `EADDRINUSE` when socket is already listening.
- Fixed `listen()` to return `EDESTADDRREQ` when socket is not bound to a local address.
- Fixed `listen()` to return `EINVAL` when socket is connecting/connected.
- Added unit test to cover `EADDRINUSE` case for `listen()`.
- Added unit test to cover `EDESTADDRREQ` case for `listen()`.
- Fixed typos in regressions.

Further Considerations
--------------------------
- A unit test that exercises the `EADDRINUSE` return condition when there is a socket listening on the target address/port pair requires `SO_REUSEADDR` support, which we currently lack.