### PR TITLE
[tcp] Enable Binding to Ephemeral Ports

### DIFF
--- a/src/protocols/ip/ephemeral.rs
+++ b/src/protocols/ip/ephemeral.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use ::libc::EAGAIN;
 use ::runtime::{
     fail::Fail,
     network::NetworkRuntime,
@@ -48,7 +47,10 @@ impl EphemeralPorts {
     }
 
     pub fn alloc(&mut self) -> Result<u16, Fail> {
-        self.ports.pop().ok_or(Fail::new(EAGAIN, "out of private ports"))
+        self.ports.pop().ok_or(Fail::new(
+            libc::EADDRINUSE,
+            "all port numbers in the ephemeral port range are currently in use",
+        ))
     }
 
     pub fn free(&mut self, port: u16) {

--- a/src/protocols/ip/ephemeral.rs
+++ b/src/protocols/ip/ephemeral.rs
@@ -53,6 +53,19 @@ impl EphemeralPorts {
         ))
     }
 
+    /// Allocates the specified port from the pool.
+    pub fn alloc_port(&mut self, port: u16) -> Result<(), Fail> {
+        // Check if port is not in the pool.
+        if !self.ports.contains(&port) {
+            return Err(Fail::new(libc::ENOENT, "port number not found"));
+        }
+
+        // Remove port from the pool.
+        self.ports.retain(|&p| p != port);
+
+        Ok(())
+    }
+
     pub fn free(&mut self, port: u16) {
         self.ports.push(port);
     }

--- a/src/protocols/ip/ephemeral.rs
+++ b/src/protocols/ip/ephemeral.rs
@@ -46,7 +46,7 @@ impl EphemeralPorts {
         port >= FIRST_PRIVATE_PORT
     }
 
-    pub fn alloc(&mut self) -> Result<u16, Fail> {
+    pub fn alloc_any(&mut self) -> Result<u16, Fail> {
         self.ports.pop().ok_or(Fail::new(
             libc::EADDRINUSE,
             "all port numbers in the ephemeral port range are currently in use",

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -261,7 +261,7 @@ impl<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> Tcp
             }
 
             // TODO: We need to free these!
-            let local_port = inner.ephemeral_ports.alloc()?;
+            let local_port = inner.ephemeral_ports.alloc_any()?;
             let local = SocketAddrV4::new(inner.rt.local_ipv4_addr(), local_port);
 
             let socket = Socket::Connecting { local, remote };

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -158,6 +158,12 @@ impl<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> Tcp
             }
         }
 
+        // Check if this is an ephemeral port.
+        if EphemeralPorts::is_private(addr.port()) {
+            // Allocate ephemeral port from the pool, to leave  ephemeral port allocator in a consistent state.
+            inner.ephemeral_ports.alloc_port(addr.port())?
+        }
+
         match inner.sockets.get_mut(&fd) {
             Some(Socket::Inactive { ref mut local }) => match *local {
                 Some(_) => return Err(Fail::new(libc::EINVAL, "socket is already bound to an address")),

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -41,7 +41,6 @@ use ::futures::channel::mpsc;
 use ::libc::{
     EAGAIN,
     EBADF,
-    EBADMSG,
     EBUSY,
     EINPROGRESS,
     EINVAL,
@@ -142,10 +141,7 @@ impl<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> Tcp
     }
 
     pub fn bind(&self, fd: QDesc, addr: SocketAddrV4) -> Result<(), Fail> {
-        let mut inner = self.inner.borrow_mut();
-        if addr.port() >= EphemeralPorts::first_private_port() {
-            return Err(Fail::new(EBADMSG, "Port number in private port range"));
-        }
+        let mut inner: RefMut<Inner<RT>> = self.inner.borrow_mut();
 
         // Check if address is already bound.
         for (_, socket) in &inner.sockets {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,7 +8,7 @@ use ::runtime::network::types::{
     Ipv4Addr,
     MacAddress,
 };
-use std::collections::HashMap;
+use ::std::collections::HashMap;
 
 // Alice Address
 pub const ALICE_IPV4: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -51,20 +51,22 @@ use ::std::{
 // Open/Close Passive Socket
 //======================================================================================================================
 
+/// Opens and closes a passive socket using a non-ephemeral port.
+fn do_passive_connection_setup(mut libos: &mut InetStack<DummyRuntime>) {
+    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
+    let sockqd: QDesc = safe_socket(&mut libos);
+    safe_bind(&mut libos, sockqd, local);
+    safe_listen(&mut libos, sockqd);
+    safe_close_passive(&mut libos, sockqd);
+}
+
 /// Tests if a passive socket may be successfully opened and closed.
 #[test]
 fn tcp_connection_setup() {
     let (tx, rx): (Sender<DataBuffer>, Receiver<DataBuffer>) = crossbeam_channel::unbounded();
     let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
-    let port: u16 = PORT_BASE;
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
-
-    // Open and close a connection.
-    let sockqd: QDesc = safe_socket(&mut libos);
-    safe_bind(&mut libos, sockqd, local);
-    safe_listen(&mut libos, sockqd);
-    safe_close_passive(&mut libos, sockqd);
+    do_passive_connection_setup(&mut libos);
 }
 
 //======================================================================================================================

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -60,6 +60,16 @@ fn do_passive_connection_setup(mut libos: &mut InetStack<DummyRuntime>) {
     safe_close_passive(&mut libos, sockqd);
 }
 
+/// Opens and closes a passive socket using an ephemeral port.
+fn do_passive_connection_setup_ephemeral(mut libos: &mut InetStack<DummyRuntime>) {
+    pub const PORT_EPHEMERAL_BASE: u16 = 49152;
+    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_EPHEMERAL_BASE);
+    let sockqd: QDesc = safe_socket(&mut libos);
+    safe_bind(&mut libos, sockqd, local);
+    safe_listen(&mut libos, sockqd);
+    safe_close_passive(&mut libos, sockqd);
+}
+
 /// Tests if a passive socket may be successfully opened and closed.
 #[test]
 fn tcp_connection_setup() {
@@ -67,6 +77,7 @@ fn tcp_connection_setup() {
     let mut libos: InetStack<DummyRuntime> = DummyLibOS::new(ALICE_MAC, ALICE_IPV4, tx, rx, arp());
 
     do_passive_connection_setup(&mut libos);
+    do_passive_connection_setup_ephemeral(&mut libos);
 }
 
 //======================================================================================================================


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/inetstack/issues/168.

Summary of Changes
------------------------

- Added unit test for "binding socket to ephemeral ports".
- Removed constraint for "binding sockets to ephemeral ports" in `bind()`.
- Added allocation for ephemeral a specific port number.
- Added rollback allocation logic in case `bind()` fails.