### PR TITLE
[ip] Accept Zero as a Wildcard Ephemeral Port in `bind()`

### DIFF
--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -70,6 +70,15 @@ fn do_passive_connection_setup_ephemeral(mut libos: &mut InetStack<DummyRuntime>
     safe_close_passive(&mut libos, sockqd);
 }
 
+/// Opens and closes a passive socket using wildcard ephemeral port.
+fn do_passive_connection_setup_wildcard_ephemeral(mut libos: &mut InetStack<DummyRuntime>) {
+    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, 0);
+    let sockqd: QDesc = safe_socket(&mut libos);
+    safe_bind(&mut libos, sockqd, local);
+    safe_listen(&mut libos, sockqd);
+    safe_close_passive(&mut libos, sockqd);
+}
+
 /// Tests if a passive socket may be successfully opened and closed.
 #[test]
 fn tcp_connection_setup() {
@@ -78,6 +87,7 @@ fn tcp_connection_setup() {
 
     do_passive_connection_setup(&mut libos);
     do_passive_connection_setup_ephemeral(&mut libos);
+    do_passive_connection_setup_wildcard_ephemeral(&mut libos);
 }
 
 //======================================================================================================================


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/inetstack/issues/169.

Summary of Changes
-------------------------

- Fixed `bind()` in TCP to accept zero as a wildcard ephemeral port
- Added support for ephemeral ports in UDP
- Enabled `bind()` in UDP to accept zero as a wildcard ephemeral port
- Added unit test for setting up a passive socket in TCP using an ephemeral port
- Added unit tests for setting up a socket in UDP using an ephemeral