### PR TITLE
[ip] Don't Reassign the Local Port When Connecting a Bound Socket

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use crate::{
             EtherType2,
             Ethernet2Header,
         },
+        tcp::operations::ConnectFuture,
         udp::UdpOperation,
         Peer,
     },
@@ -278,7 +279,10 @@ impl<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> Ine
         trace!("connect(): qd={:?} remote={:?}", qd, remote);
         let future = match self.file_table.get(qd) {
             Some(qtype) => match QType::try_from(qtype) {
-                Ok(QType::TcpSocket) => Ok(FutureOperation::from(self.ipv4.tcp.connect(qd, remote))),
+                Ok(QType::TcpSocket) => {
+                    let fut: ConnectFuture<RT> = self.ipv4.tcp.connect(qd, remote)?;
+                    Ok(FutureOperation::from(fut))
+                },
                 _ => Err(Fail::new(EINVAL, "invalid queue type")),
             },
             _ => Err(Fail::new(EBADF, "bad queue descriptor")),

--- a/src/protocols/tcp/operations.rs
+++ b/src/protocols/tcp/operations.rs
@@ -123,14 +123,8 @@ impl<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> Tcp
     }
 }
 
-pub enum ConnectFutureState {
-    Failed(Fail),
-    InProgress,
-}
-
 pub struct ConnectFuture<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> {
     pub fd: QDesc,
-    pub state: ConnectFutureState,
     pub inner: Rc<RefCell<Inner<RT>>>,
 }
 
@@ -145,10 +139,7 @@ impl<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> Fut
 
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
         let self_ = self.get_mut();
-        match self_.state {
-            ConnectFutureState::Failed(ref e) => Poll::Ready(Err(e.clone())),
-            ConnectFutureState::InProgress => self_.inner.borrow_mut().poll_connect_finished(self_.fd, context),
-        }
+        self_.inner.borrow_mut().poll_connect_finished(self_.fd, context)
     }
 }
 

--- a/src/test_helpers/engine.rs
+++ b/src/test_helpers/engine.rs
@@ -115,7 +115,7 @@ impl<RT: SchedulerRuntime + UtilsRuntime + NetworkRuntime + Clone + 'static> Eng
     }
 
     pub fn tcp_connect(&mut self, socket_fd: QDesc, remote_endpoint: SocketAddrV4) -> ConnectFuture<RT> {
-        self.ipv4.tcp.connect(socket_fd, remote_endpoint)
+        self.ipv4.tcp.connect(socket_fd, remote_endpoint).unwrap()
     }
 
     pub fn tcp_bind(&mut self, socket_fd: QDesc, endpoint: SocketAddrV4) -> Result<(), Fail> {


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/inetstack/issues/174.

Summary of Changes
------------------------

- Changed signature of `connect()` to return `Result<>`, thus enabling failing instead of panicking.
- Dropped useless `ConnectionFutureState` enumeration, if the operation fails straightaway there is no need to spawn a future.
- Added missing checks in `connect()` for cases in which the socket is connecting / connected.
- Fixed port reassigning when connecting bound sockets.
- Added unit test for establishing a connection using a bound active socket.