### PR TITLE
[ip] Fixed Misidentification of Fragments in IPv4 Header Parsing

### DIFF
--- a/src/protocols/ipv4/datagram.rs
+++ b/src/protocols/ipv4/datagram.rs
@@ -74,9 +74,9 @@ pub struct Ipv4Header {
     ecn: u8,
     /// Total length of the packet including header and data (16 bits).
     total_length: u16,
-    /// Identifies the to which datagram a fragment belongs to (16 bits).
+    /// Used to identify the datagram to which a fragment belongs (16 bits).
     identification: u16,
-    /// Version control flags (3 bits).
+    /// Control flags (3 bits).
     flags: u8,
     /// Fragment offset indicates where in the datagram this fragment belongs to (13 bits).
     fragment_offset: u16,
@@ -261,19 +261,19 @@ impl Ipv4Header {
         // DSCP + ECN.
         buf[1] = (self.dscp << 2) | (self.ecn & 3);
 
-        // Total length.
+        // Total Length.
         NetworkEndian::write_u16(&mut buf[2..4], IPV4_HEADER_MIN_SIZE + (payload_len as u16));
 
-        // Fragment identification.
+        // Identification.
         NetworkEndian::write_u16(&mut buf[4..6], self.identification);
 
-        // Fragment flags and offset.
+        // Flags and Fragment Offset.
         NetworkEndian::write_u16(
             &mut buf[6..8],
             (self.flags as u16) << 13 | self.fragment_offset & 0x1fff,
         );
 
-        // Time to live.
+        // Time to Live.
         buf[8] = self.ttl;
 
         // Protocol.
@@ -281,13 +281,13 @@ impl Ipv4Header {
 
         // Skip the checksum (bytes 10..12) until we finish writing the header.
 
-        // Source address.
+        // Source Address.
         buf[12..16].copy_from_slice(&self.src_addr.octets());
 
-        // Destination address.
+        // Destination Address.
         buf[16..20].copy_from_slice(&self.dst_addr.octets());
 
-        // Header checksum.
+        // Header Checksum.
         let checksum: u16 = Self::compute_checksum(buf);
         NetworkEndian::write_u16(&mut buf[10..12], checksum);
     }

--- a/src/protocols/ipv4/datagram.rs
+++ b/src/protocols/ipv4/datagram.rs
@@ -48,11 +48,14 @@ const DEFAULT_IPV4_TTL: u8 = 255;
 /// Version number for IPv4.
 const IPV4_VERSION: u8 = 4;
 
+/// IPv4 Control Flag: Datagram has evil intent (see RFC 3514).
+const IPV4_CTRL_FLAG_EVIL: u8 = 0x4;
+
 /// IPv4 Control Flag: Don't Fragment.
 const IPV4_CTRL_FLAG_DF: u8 = 0x2;
 
 /// IPv4 Control Flag: More Fragments.
-const _IPV4_CTRL_FLAG_MF: u8 = 0x1;
+const IPV4_CTRL_FLAG_MF: u8 = 0x1;
 
 //==============================================================================
 // Structures
@@ -166,18 +169,28 @@ impl Ipv4Header {
             return Err(Fail::new(EBADMSG, "ipv4 datagram size mismatch"));
         }
 
-        // Fragment identification.
+        // Identification (Id).
+        //
+        // Note: We had a (now removed) bug here in that we were _requiring_ all incoming datagrams to have an Id field
+        // of zero.  This was horribly misguided.  With the exception of datagramss where the DF (don't fragment) flag
+        // is set, all IPv4 datagrams are _required_ to have a (temporally) unique identification field for datagrams
+        // with the same source, destination, and protocol.  Thus we should expect most datagrams to have a non-zero Id.
         let identification: u16 = NetworkEndian::read_u16(&hdr_buf[4..6]);
-        // TODO: drop this check once we support fragmentation.
-        if identification != 0 {
-            warn!("fragmentation is not supported identification={:?}", identification);
-            return Err(Fail::new(ENOTSUP, "ipv4 fragmentation is not supported"));
-        }
 
         // Control flags.
-        let flags: u8 = (NetworkEndian::read_u16(&hdr_buf[6..8]) >> 13) as u8;
+        //
+        // Note: We had a (now removed) bug here in that we were _requiring_ all incoming datagrams to have the DF
+        // (don't fragment) bit set.  This appears to be because we don't support fragmentation (yet anyway).  But the
+        // lack of a set DF bit doesn't make a datagram a fragment.  So we should accept datagrams regardless of the
+        // setting of this bit.
+        let flags: u8 = hdr_buf[6] >> 5;
+        // Don't accept evil datagrams (see RFC 3514).
+        if flags & IPV4_CTRL_FLAG_EVIL != 0 {
+            return Err(Fail::new(EBADMSG, "ipv4 datagram is marked as evil"));
+        }
+
         // TODO: drop this check once we support fragmentation.
-        if flags != IPV4_CTRL_FLAG_DF {
+        if flags & IPV4_CTRL_FLAG_MF != 0 {
             warn!("fragmentation is not supported flags={:?}", flags);
             return Err(Fail::new(ENOTSUP, "ipv4 fragmentation is not supported"));
         }


### PR DESCRIPTION
This PR fixes Issues #162 and #183.

The stack was mistakenly identifying IPv4 datagrams with a non-zero Identification field, or a cleared DF (don't fragment) bit in the Flags field, as fragments.  And then rejecting them (since we don't support fragmentation yet).  Neither of these fields is a reliable indicator of a fragment.

This PR:
- Removes the two bogus checks that were rejecting otherwise valid datagrams.
- Adds a new check for correctly identifying and rejecting fragments.
- Adds a new check for identifying and rejecting datagrams with the Reserved bit set in the Flags field.
- Fixes the tests for the above situations to test for the actual correct behavior.