### PR TITLE
[contrib] Updating `runtime` and Dropping `SchedulerRuntime`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-derive = "0.3.3"
 num-traits = "0.2.15"
 rand = { version = "0.8.5", features = ["small_rng"] }
 
-runtime = { git = "https://github.com/demikernel/runtime", rev = "6840b8d9472207edc61c01c79f2d33ebfaf5aa8c" }
+runtime = { git = "https://github.com/demikernel/runtime", rev = "0addd02918cc50e4f9c5210ecbfea89bea3227b5" }
 
 [features]
 profiler = [ "runtime/perftools" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 [package]
 name = "inetstack"
 version = "1.1.1"

--- a/src/futures/operation/mod.rs
+++ b/src/futures/operation/mod.rs
@@ -9,7 +9,6 @@ use ::futures::Future;
 use ::runtime::{
     network::NetworkRuntime,
     scheduler::SchedulerFuture,
-    task::SchedulerRuntime,
 };
 use ::std::{
     any::Any,
@@ -34,7 +33,7 @@ use ::std::{
 ///
 /// [Background](Operation::Background) tasks are heap-allocated as they are expected to live
 /// long so we allocate them on the heap.
-pub enum FutureOperation<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> {
+pub enum FutureOperation<RT: NetworkRuntime + Clone + 'static> {
     Tcp(TcpOperation<RT>),
     Udp(UdpOperation),
 
@@ -42,7 +41,7 @@ pub enum FutureOperation<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static
     Background(Pin<Box<dyn Future<Output = ()>>>),
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> SchedulerFuture for FutureOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> SchedulerFuture for FutureOperation<RT> {
     fn as_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
@@ -58,7 +57,7 @@ impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> SchedulerFuture fo
 
 /// Simple wrapper which calls the corresponding [poll](Future::poll) method for each enum variant's
 /// type.
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for FutureOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> Future for FutureOperation<RT> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
@@ -72,7 +71,7 @@ impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for FutureO
 
 impl<T, RT> From<T> for FutureOperation<RT>
 where
-    RT: SchedulerRuntime + NetworkRuntime + Clone + 'static,
+    RT: NetworkRuntime + Clone + 'static,
     T: Into<TcpOperation<RT>>,
 {
     fn from(f: T) -> Self {

--- a/src/protocols/arp/cache/mod.rs
+++ b/src/protocols/arp/cache/mod.rs
@@ -5,7 +5,10 @@
 mod tests;
 
 use crate::collections::HashTtlCache;
-use ::runtime::network::types::MacAddress;
+use ::runtime::{
+    network::types::MacAddress,
+    timer::TimerRc,
+};
 use ::std::{
     collections::HashMap,
     net::Ipv4Addr,
@@ -51,13 +54,13 @@ pub struct ArpCache {
 impl ArpCache {
     /// Creates an ARP Cache.
     pub fn new(
-        now: Instant,
+        clock: TimerRc,
         default_ttl: Option<Duration>,
         values: Option<&HashMap<Ipv4Addr, MacAddress>>,
         disable: bool,
     ) -> ArpCache {
         let mut peer = ArpCache {
-            cache: HashTtlCache::new(now, default_ttl),
+            cache: HashTtlCache::new(clock.now(), default_ttl),
             disable,
         };
 

--- a/src/protocols/arp/cache/tests.rs
+++ b/src/protocols/arp/cache/tests.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use ::runtime::timer::Timer;
+use ::std::rc::Rc;
+
 use super::*;
 use crate::test_helpers;
 
@@ -10,9 +13,10 @@ fn evit_with_default_ttl() {
     let now = Instant::now();
     let ttl = Duration::from_secs(1);
     let later = now + ttl;
+    let clock = TimerRc(Rc::new(Timer::new(now)));
 
     // Insert an IPv4 address in the ARP Cache.
-    let mut cache = ArpCache::new(now, Some(ttl), None, false);
+    let mut cache = ArpCache::new(clock, Some(ttl), None, false);
     cache.insert(test_helpers::ALICE_IPV4, test_helpers::ALICE_MAC);
     assert!(cache.get(test_helpers::ALICE_IPV4) == Some(&test_helpers::ALICE_MAC));
 
@@ -29,13 +33,14 @@ fn evit_with_default_ttl() {
 fn import() {
     let now = Instant::now();
     let ttl = Duration::from_secs(1);
+    let clock = TimerRc(Rc::new(Timer::new(now)));
 
     // Create an address resolution map.
     let mut map: HashMap<Ipv4Addr, MacAddress> = HashMap::new();
     map.insert(test_helpers::ALICE_IPV4, test_helpers::ALICE_MAC);
 
     // Create an ARP Cache and import address resolution map.
-    let cache = ArpCache::new(now, Some(ttl), Some(&map), false);
+    let cache = ArpCache::new(clock, Some(ttl), Some(&map), false);
 
     // Check if address resolutions are in the ARP Cache.
     assert!(cache.get(test_helpers::ALICE_IPV4) == Some(&test_helpers::ALICE_MAC));
@@ -46,9 +51,10 @@ fn import() {
 fn export() {
     let now = Instant::now();
     let ttl = Duration::from_secs(1);
+    let clock = TimerRc(Rc::new(Timer::new(now)));
 
     // Insert an IPv4 address in the ARP Cache.
-    let mut cache = ArpCache::new(now, Some(ttl), None, false);
+    let mut cache = ArpCache::new(clock, Some(ttl), None, false);
     cache.insert(test_helpers::ALICE_IPV4, test_helpers::ALICE_MAC);
     assert!(cache.get(test_helpers::ALICE_IPV4) == Some(&test_helpers::ALICE_MAC));
 

--- a/src/protocols/arp/tests.rs
+++ b/src/protocols/arp/tests.rs
@@ -23,12 +23,9 @@ use ::libc::{
     EBADMSG,
     ETIMEDOUT,
 };
-use ::runtime::{
-    network::{
-        types::MacAddress,
-        NetworkRuntime,
-    },
-    task::SchedulerRuntime,
+use ::runtime::network::{
+    types::MacAddress,
+    NetworkRuntime,
 };
 use ::std::{
     future::Future,
@@ -56,7 +53,7 @@ fn immediate_reply() {
     let now = now + Duration::from_micros(1);
     assert!(Future::poll(fut.as_mut(), &mut ctx).is_pending());
 
-    alice.rt().advance_clock(now);
+    alice.clock.advance_clock(now);
     let rt: &mut TestRuntime = alice.rt();
     let request = rt.pop_frame();
 
@@ -77,13 +74,13 @@ fn immediate_reply() {
     let cache = carrie.export_arp_cache();
     assert_eq!(cache.get(&test_helpers::ALICE_IPV4), Some(&test_helpers::ALICE_MAC));
 
-    carrie.rt().advance_clock(now);
+    carrie.clock.advance_clock(now);
     let reply = carrie.rt().pop_frame();
 
     info!("passing ARP reply back to alice...");
     alice.receive(reply).unwrap();
     let now = now + Duration::from_micros(1);
-    alice.rt().advance_clock(now);
+    alice.clock.advance_clock(now);
     let link_addr = match Future::poll(fut.as_mut(), &mut ctx) {
         Poll::Ready(Ok(link_addr)) => Ok(link_addr),
         _ => Err(()),
@@ -110,7 +107,7 @@ fn slow_reply() {
 
     // move time forward enough to trigger a timeout.
     now += Duration::from_secs(1);
-    alice.rt().advance_clock(now);
+    alice.clock.advance_clock(now);
     assert!(Future::poll(fut.as_mut(), &mut ctx).is_pending());
 
     let request = alice.rt().pop_frame();
@@ -133,12 +130,12 @@ fn slow_reply() {
     let cache = carrie.export_arp_cache();
     assert_eq!(cache.get(&test_helpers::ALICE_IPV4), Some(&test_helpers::ALICE_MAC));
 
-    carrie.rt().advance_clock(now);
+    carrie.clock.advance_clock(now);
     let reply = carrie.rt().pop_frame();
 
     alice.receive(reply).unwrap();
     now += Duration::from_micros(1);
-    alice.rt().advance_clock(now);
+    alice.clock.advance_clock(now);
     let link_addr: MacAddress = match Future::poll(fut.as_mut(), &mut ctx) {
         Poll::Ready(Ok(link_addr)) => Ok(link_addr),
         _ => Err(()),
@@ -168,7 +165,7 @@ fn no_reply() {
 
     for i in 0..options.get_retry_count() {
         now += options.get_request_timeout();
-        alice.rt().advance_clock(now);
+        alice.clock.advance_clock(now);
         assert!(Future::poll(fut.as_mut(), &mut ctx).is_pending());
         info!("no_reply(): retry #{}", i + 1);
         let bytes = alice.rt().pop_frame();
@@ -179,7 +176,7 @@ fn no_reply() {
 
     // timeout
     now += options.get_request_timeout();
-    alice.rt().advance_clock(now);
+    alice.clock.advance_clock(now);
     match Future::poll(fut.as_mut(), &mut ctx) {
         Poll::Ready(Err(error)) if error.errno == ETIMEDOUT => Ok(()),
         _ => Err(()),

--- a/src/protocols/icmpv4/tests.rs
+++ b/src/protocols/icmpv4/tests.rs
@@ -6,7 +6,6 @@ use ::futures::task::{
     noop_waker_ref,
     Context,
 };
-use ::runtime::task::SchedulerRuntime;
 use ::std::{
     future::Future,
     pin::Pin,
@@ -39,8 +38,8 @@ fn ipv4_ping() {
     .unwrap();
 
     now += Duration::from_secs(1);
-    alice.rt().advance_clock(now);
-    bob.rt().advance_clock(now);
+    alice.clock.advance_clock(now);
+    bob.clock.advance_clock(now);
 
     // Bob receives ping request from Alice.
     bob.receive(alice.rt().pop_frame()).unwrap();
@@ -49,8 +48,8 @@ fn ipv4_ping() {
     bob.rt().poll_scheduler();
 
     now += Duration::from_secs(1);
-    alice.rt().advance_clock(now);
-    bob.rt().advance_clock(now);
+    alice.clock.advance_clock(now);
+    bob.clock.advance_clock(now);
 
     // Alice receives reply from Bob.
     alice.receive(bob.rt().pop_frame()).unwrap();
@@ -82,8 +81,8 @@ fn ipv4_ping_loop() {
         .unwrap();
 
         now += Duration::from_secs(1);
-        alice.rt().advance_clock(now);
-        bob.rt().advance_clock(now);
+        alice.clock.advance_clock(now);
+        bob.clock.advance_clock(now);
 
         // Bob receives ping request from Alice.
         bob.receive(alice.rt().pop_frame()).unwrap();
@@ -92,8 +91,8 @@ fn ipv4_ping_loop() {
         bob.rt().poll_scheduler();
 
         now += Duration::from_secs(1);
-        alice.rt().advance_clock(now);
-        bob.rt().advance_clock(now);
+        alice.clock.advance_clock(now);
+        bob.clock.advance_clock(now);
 
         // Alice receives reply from Bob.
         alice.receive(bob.rt().pop_frame()).unwrap();

--- a/src/protocols/tcp/established/background/mod.rs
+++ b/src/protocols/tcp/established/background/mod.rs
@@ -17,7 +17,6 @@ use ::futures::{
 };
 use ::runtime::{
     network::NetworkRuntime,
-    task::SchedulerRuntime,
     QDesc,
 };
 use ::std::{
@@ -25,9 +24,9 @@ use ::std::{
     rc::Rc,
 };
 
-pub type BackgroundFuture<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> = impl Future<Output = ()>;
+pub type BackgroundFuture<RT: NetworkRuntime + Clone + 'static> = impl Future<Output = ()>;
 
-pub fn background<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static>(
+pub fn background<RT: NetworkRuntime + Clone + 'static>(
     cb: Rc<ControlBlock<RT>>,
     fd: QDesc,
     _dead_socket_tx: mpsc::UnboundedSender<QDesc>,

--- a/src/protocols/tcp/operations.rs
+++ b/src/protocols/tcp/operations.rs
@@ -11,7 +11,6 @@ use ::runtime::{
     memory::Buffer,
     network::NetworkRuntime,
     scheduler::FutureResult,
-    task::SchedulerRuntime,
     QDesc,
 };
 use ::std::{
@@ -26,38 +25,38 @@ use ::std::{
     },
 };
 
-pub enum TcpOperation<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> {
+pub enum TcpOperation<RT: NetworkRuntime + Clone + 'static> {
     Accept(FutureResult<AcceptFuture<RT>>),
     Connect(FutureResult<ConnectFuture<RT>>),
     Pop(FutureResult<PopFuture<RT>>),
     Push(FutureResult<PushFuture>),
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> From<AcceptFuture<RT>> for TcpOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> From<AcceptFuture<RT>> for TcpOperation<RT> {
     fn from(f: AcceptFuture<RT>) -> Self {
         TcpOperation::Accept(FutureResult::new(f, None))
     }
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> From<ConnectFuture<RT>> for TcpOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> From<ConnectFuture<RT>> for TcpOperation<RT> {
     fn from(f: ConnectFuture<RT>) -> Self {
         TcpOperation::Connect(FutureResult::new(f, None))
     }
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> From<PushFuture> for TcpOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> From<PushFuture> for TcpOperation<RT> {
     fn from(f: PushFuture) -> Self {
         TcpOperation::Push(FutureResult::new(f, None))
     }
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> From<PopFuture<RT>> for TcpOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> From<PopFuture<RT>> for TcpOperation<RT> {
     fn from(f: PopFuture<RT>) -> Self {
         TcpOperation::Pop(FutureResult::new(f, None))
     }
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for TcpOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> Future for TcpOperation<RT> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<()> {
@@ -70,7 +69,7 @@ impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for TcpOper
     }
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> TcpOperation<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> TcpOperation<RT> {
     pub fn expect_result(self) -> (QDesc, Option<QDesc>, OperationResult) {
         match self {
             // Connect operation.
@@ -118,18 +117,18 @@ impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> TcpOperation<RT> {
     }
 }
 
-pub struct ConnectFuture<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> {
+pub struct ConnectFuture<RT: NetworkRuntime + Clone + 'static> {
     pub fd: QDesc,
     pub inner: Rc<RefCell<Inner<RT>>>,
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> fmt::Debug for ConnectFuture<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> fmt::Debug for ConnectFuture<RT> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ConnectFuture({:?})", self.fd)
     }
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for ConnectFuture<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> Future for ConnectFuture<RT> {
     type Output = Result<(), Fail>;
 
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
@@ -139,7 +138,7 @@ impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for Connect
 }
 
 /// Accept Operation Descriptor
-pub struct AcceptFuture<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> {
+pub struct AcceptFuture<RT: NetworkRuntime + Clone + 'static> {
     /// Queue descriptor of listening socket.
     qd: QDesc,
     // Pre-booked queue descriptor for incoming connection.
@@ -149,7 +148,7 @@ pub struct AcceptFuture<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static>
 }
 
 /// Associated Functions for Accept Operation Descriptors
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> AcceptFuture<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> AcceptFuture<RT> {
     /// Creates a descriptor for an accept operation.
     pub fn new(qd: QDesc, new_qd: QDesc, inner: Rc<RefCell<Inner<RT>>>) -> Self {
         Self { qd, new_qd, inner }
@@ -157,14 +156,14 @@ impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> AcceptFuture<RT> {
 }
 
 /// Debug Trait Implementation for Accept Operation Descriptors
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> fmt::Debug for AcceptFuture<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> fmt::Debug for AcceptFuture<RT> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "AcceptFuture({:?})", self.qd)
     }
 }
 
 /// Future Trait Implementation for Accept Operation Descriptors
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for AcceptFuture<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> Future for AcceptFuture<RT> {
     type Output = Result<QDesc, Fail>;
 
     /// Polls the underlying accept operation.
@@ -200,18 +199,18 @@ impl Future for PushFuture {
     }
 }
 
-pub struct PopFuture<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> {
+pub struct PopFuture<RT: NetworkRuntime + Clone + 'static> {
     pub fd: QDesc,
     pub inner: Rc<RefCell<Inner<RT>>>,
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> fmt::Debug for PopFuture<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> fmt::Debug for PopFuture<RT> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "PopFuture({:?})", self.fd)
     }
 }
 
-impl<RT: SchedulerRuntime + NetworkRuntime + Clone + 'static> Future for PopFuture<RT> {
+impl<RT: NetworkRuntime + Clone + 'static> Future for PopFuture<RT> {
     type Output = Result<Buffer, Fail>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {

--- a/src/protocols/tcp/tests/setup.rs
+++ b/src/protocols/tcp/tests/setup.rs
@@ -44,7 +44,6 @@ use ::runtime::{
         NetworkRuntime,
         PacketBuf,
     },
-    task::SchedulerRuntime,
     QDesc,
 };
 use ::std::{
@@ -488,10 +487,10 @@ pub fn advance_clock(
 ) {
     *now += Duration::from_secs(1);
     if let Some(server) = server {
-        server.rt().advance_clock(*now);
+        server.clock.advance_clock(*now);
     }
     if let Some(client) = client {
-        client.rt().advance_clock(*now);
+        client.clock.advance_clock(*now);
     }
 }
 

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -7,13 +7,17 @@ pub mod runtime;
 pub use self::runtime::TestRuntime;
 pub use engine::Engine;
 
-use ::runtime::network::{
-    config::{
-        ArpConfig,
-        TcpConfig,
-        UdpConfig,
+use ::runtime::{
+    network::{
+        config::{
+            ArpConfig,
+            TcpConfig,
+            UdpConfig,
+        },
+        types::MacAddress,
     },
-    types::MacAddress,
+    scheduler::Scheduler,
+    timer::TimerRc,
 };
 use ::std::{
     collections::HashMap,
@@ -57,7 +61,9 @@ pub fn new_alice(now: Instant) -> Engine<TestRuntime> {
     let udp_options = UdpConfig::default();
     let tcp_options = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_options, tcp_options, ALICE_MAC, ALICE_IPV4);
-    Engine::new(rt).unwrap()
+    let scheduler: Scheduler = rt.scheduler.clone();
+    let clock: TimerRc = rt.clock.clone();
+    Engine::new(rt, scheduler, clock).unwrap()
 }
 
 pub fn new_bob(now: Instant) -> Engine<TestRuntime> {
@@ -71,7 +77,9 @@ pub fn new_bob(now: Instant) -> Engine<TestRuntime> {
     let udp_options = UdpConfig::default();
     let tcp_options = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_options, tcp_options, BOB_MAC, BOB_IPV4);
-    Engine::new(rt).unwrap()
+    let scheduler: Scheduler = rt.scheduler.clone();
+    let clock: TimerRc = rt.clock.clone();
+    Engine::new(rt, scheduler, clock).unwrap()
 }
 
 pub fn new_alice2(now: Instant) -> Engine<TestRuntime> {
@@ -88,7 +96,9 @@ pub fn new_alice2(now: Instant) -> Engine<TestRuntime> {
     let udp_options = UdpConfig::default();
     let tcp_options = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_options, tcp_options, ALICE_MAC, ALICE_IPV4);
-    Engine::new(rt).unwrap()
+    let scheduler: Scheduler = rt.scheduler.clone();
+    let clock: TimerRc = rt.clock.clone();
+    Engine::new(rt, scheduler, clock).unwrap()
 }
 
 pub fn new_bob2(now: Instant) -> Engine<TestRuntime> {
@@ -105,7 +115,9 @@ pub fn new_bob2(now: Instant) -> Engine<TestRuntime> {
     let udp_options = UdpConfig::default();
     let tcp_options = TcpConfig::default();
     let rt = TestRuntime::new(now, arp_options, udp_options, tcp_options, BOB_MAC, BOB_IPV4);
-    Engine::new(rt).unwrap()
+    let scheduler: Scheduler = rt.scheduler.clone();
+    let clock: TimerRc = rt.clock.clone();
+    Engine::new(rt, scheduler, clock).unwrap()
 }
 
 pub fn new_carrie(now: Instant) -> Engine<TestRuntime> {
@@ -120,5 +132,7 @@ pub fn new_carrie(now: Instant) -> Engine<TestRuntime> {
     let tcp_options = TcpConfig::default();
 
     let rt = TestRuntime::new(now, arp_options, udp_options, tcp_options, CARRIE_MAC, CARRIE_IPV4);
-    Engine::new(rt).unwrap()
+    let scheduler: Scheduler = rt.scheduler.clone();
+    let clock: TimerRc = rt.clock.clone();
+    Engine::new(rt, scheduler, clock).unwrap()
 }

--- a/tests/common/libos.rs
+++ b/tests/common/libos.rs
@@ -18,6 +18,8 @@ use ::runtime::{
         DataBuffer,
     },
     network::types::MacAddress,
+    scheduler::Scheduler,
+    timer::TimerRc,
 };
 use ::std::{
     collections::HashMap,
@@ -46,9 +48,11 @@ impl DummyLibOS {
     ) -> InetStack<DummyRuntime> {
         let now: Instant = Instant::now();
         let rt: DummyRuntime = DummyRuntime::new(now, link_addr, ipv4_addr, rx, tx, arp);
+        let scheduler: Scheduler = rt.scheduler.clone();
+        let clock: TimerRc = rt.clock.clone();
         let rng_seed: [u8; 32] = [0; 32];
         logging::initialize();
-        InetStack::new(rt, rng_seed).unwrap()
+        InetStack::new(rt, scheduler, clock, rng_seed).unwrap()
     }
 
     /// Cooks a buffer.


### PR DESCRIPTION
Description
-------------

This PR updates the `runtime` crate.

Summary of Changes
-------------------------

- Updated `runtime` crate, which dropped trait bounds on the `SchedulerRuntime`
- Dropped `SchedulerRuntime` use from `Inetstack`
- Added `scheduler` and `clock` members to `Inetstack`, `Peer`, `Icpmv4Peer` `UdpPeer`, `TcpPeer` and `ArpPeer`

Further Considerations
---------------------------

- The changes unveiled that we should fix the signature of all functions that spawn co-routines, to enable failling instead of panicking.
- The changes unveiled a redundant interface for `TimerRc`.
- Once we drop `RT: Runtime`, we shall encapsulate all runtime objects (ex: `rng_seed`, `scheduler`, `clock`) on a structure.