### PR TITLE
[inetstack] Constructors should fail instead of panicking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ impl<RT: NetworkRuntime + Clone + 'static> InetStack<RT> {
     pub fn new(rt: RT, scheduler: Scheduler, clock: TimerRc, rng_seed: [u8; 32]) -> Result<Self, Fail> {
         let file_table: IoQueueTable = IoQueueTable::new();
         let arp: ArpPeer<RT> = ArpPeer::new(rt.clone(), scheduler.clone(), clock.clone(), rt.arp_options())?;
-        let ipv4: Peer<RT> = Peer::new(rt.clone(), scheduler.clone(), clock.clone(), arp.clone(), rng_seed);
+        let ipv4: Peer<RT> = Peer::new(rt.clone(), scheduler.clone(), clock.clone(), arp.clone(), rng_seed)?;
         Ok(Self {
             arp,
             ipv4,

--- a/src/protocols/peer.rs
+++ b/src/protocols/peer.rs
@@ -37,7 +37,13 @@ pub struct Peer<RT: NetworkRuntime + Clone + 'static> {
 }
 
 impl<RT: NetworkRuntime + Clone + 'static> Peer<RT> {
-    pub fn new(rt: RT, scheduler: Scheduler, clock: TimerRc, arp: ArpPeer<RT>, rng_seed: [u8; 32]) -> Peer<RT> {
+    pub fn new(
+        rt: RT,
+        scheduler: Scheduler,
+        clock: TimerRc,
+        arp: ArpPeer<RT>,
+        rng_seed: [u8; 32],
+    ) -> Result<Peer<RT>, Fail> {
         let local_link_addr: MacAddress = rt.local_link_addr();
         let local_ipv4_addr: Ipv4Addr = rt.local_ipv4_addr();
         let udp_offload_checksum: bool = rt.udp_options().get_tx_checksum_offload();
@@ -49,12 +55,12 @@ impl<RT: NetworkRuntime + Clone + 'static> Peer<RT> {
             local_ipv4_addr,
             udp_offload_checksum,
             arp.clone(),
-        );
+        )?;
         let icmpv4: Icmpv4Peer<RT> =
-            Icmpv4Peer::new(rt.clone(), scheduler.clone(), clock.clone(), arp.clone(), rng_seed);
-        let tcp: TcpPeer<RT> = TcpPeer::new(rt.clone(), scheduler.clone(), clock.clone(), arp, rng_seed);
+            Icmpv4Peer::new(rt.clone(), scheduler.clone(), clock.clone(), arp.clone(), rng_seed)?;
+        let tcp: TcpPeer<RT> = TcpPeer::new(rt.clone(), scheduler.clone(), clock.clone(), arp, rng_seed)?;
 
-        Peer { rt, icmpv4, tcp, udp }
+        Ok(Peer { rt, icmpv4, tcp, udp })
     }
 
     pub fn receive(&mut self, buf: Buffer) -> Result<(), Fail> {

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -127,7 +127,13 @@ pub struct TcpPeer<RT: NetworkRuntime + Clone + 'static> {
 //==============================================================================
 
 impl<RT: NetworkRuntime + Clone + 'static> TcpPeer<RT> {
-    pub fn new(rt: RT, scheduler: Scheduler, clock: TimerRc, arp: ArpPeer<RT>, rng_seed: [u8; 32]) -> Self {
+    pub fn new(
+        rt: RT,
+        scheduler: Scheduler,
+        clock: TimerRc,
+        arp: ArpPeer<RT>,
+        rng_seed: [u8; 32],
+    ) -> Result<Self, Fail> {
         let (tx, rx) = mpsc::unbounded();
         let inner = Rc::new(RefCell::new(Inner::new(
             rt.clone(),
@@ -138,7 +144,7 @@ impl<RT: NetworkRuntime + Clone + 'static> TcpPeer<RT> {
             tx,
             rx,
         )));
-        Self { inner }
+        Ok(Self { inner })
     }
 
     /// Opens a TCP socket.

--- a/src/test_helpers/engine.rs
+++ b/src/test_helpers/engine.rs
@@ -53,7 +53,7 @@ impl<RT: NetworkRuntime + Clone + 'static> Engine<RT> {
         let file_table = IoQueueTable::new();
         let arp = ArpPeer::new(rt.clone(), scheduler.clone(), clock.clone(), rt.arp_options())?;
         let rng_seed: [u8; 32] = [0; 32];
-        let ipv4 = Peer::new(rt.clone(), scheduler.clone(), clock.clone(), arp.clone(), rng_seed);
+        let ipv4 = Peer::new(rt.clone(), scheduler.clone(), clock.clone(), arp.clone(), rng_seed)?;
         Ok(Engine {
             rt,
             clock,


### PR DESCRIPTION
This PR fixes Issue #191 

The following peers' constructors panic on errors: `UdpPeer`, `Icmpv4Peer`, `Peer`, and `TcpPeer`. Instead of panicking, those peers' constructors should return a `Result<T, Fail>`

This PR:

    Removes the `panic!` from UdpPeer and Icmpv4Peer and instead returns an Err(Fail)
    Wraps the returned peer in an Ok(<Peer>) for UdpPeer, Icmpv4Peer, and TcpPeer
    Changes the signature of the constructors of UdpPeer, Icmpv4Peer, TcpPeer, and Peer to return Result<T, Fail> 
    Fixed up usage of these constructors in tests and in lib.rs to propagate the error